### PR TITLE
Fixing double prefix issue of files in the root directory

### DIFF
--- a/bin/bootstrap-prefixer.js
+++ b/bin/bootstrap-prefixer.js
@@ -39,7 +39,6 @@
         }
         return _results;
       };
-      glob("" + lessPath + "/*.less", handle);
       glob("" + lessPath + "/**/*.less", handle);
       return console.log('Finished prefixing.');
     });


### PR DESCRIPTION
Hey Petr, thanks for the module! Very useful.

I found one small issue with it. Less files in the root directory get prefixed twice. This is probably due to some changes in the 'glob' module done after you developed the module (see the first comment of [this SO question](http://stackoverflow.com/questions/23809897/node-js-glob-pattern-for-excluding-multiple-files)). Glob function is called twice (lines 42 and 43) in the bootstrap-prefixer.js file - once for files in root, and then for all .less files in the root directory and all 1-level subdirectories. The first call is not necessary anymore, as the second one 'catches' the root and all subdirectories.